### PR TITLE
ParseTree finished (important note at the end of description)

### DIFF
--- a/Automat/includes/Syntax.h
+++ b/Automat/includes/Syntax.h
@@ -36,12 +36,12 @@ class Syntax {
 							 "  --*:--  ", "Prohibited", " --null-- ", "PlusToken ", // 16-19
 							 "MinusToken", "NotToken  ", "AndToken  ", "SemicolTok", // 20-23
 							 "Paranth ( ", "Paranth ) ", "Braces {  ", "Braces }  ", // 24-27
-							 "Brackets [", "Brackets ]" ,"IfToken   ", "WhileToken"//, // 28-31
-							 //"INT-Token ", "WRITE-Toke", "ELSE-Token", "READ-Token"  // 32-35
+							 "Brackets [", "Brackets ]" ,"IfToken   ", "WhileToken", // 28-31
+							 "INT-Token ", "WRITE-Toke", "ELSE-Token", "READ-Token"  // 32-35
 	};
 	const char signArray[SIGN_ARRAY_SZ] = {'+', '-', '!', '&', ';', '(', ')','{', '}', '[', ']'};
 
-	char* keywordsArray[KEYWORD_NUMBER * 2] = {"if", "IF", "while", "WHILE"}; /*, "int", "INT", "write", "WRITE", "else", "ELSE", "read", "READ"};*/
+	char* keywordsArray[KEYWORD_NUMBER * 2] = {"if", "IF", "while", "WHILE", "int", "INT", "write", "WRITE", "else", "ELSE", "read", "READ"};
 
 public:
 	int keywordNumber;

--- a/Automat/src/Automat.cpp
+++ b/Automat/src/Automat.cpp
@@ -76,7 +76,7 @@ void Automat::reset() {
 }
 
 /*
- * maps actual character to a corresponding symbol in the StateTable
+ * maps current character to a corresponding symbol in the StateTable
  * @return corresponding symbol for the StateTable
  */
 int Automat::mapCharToSymbolName(char c) {

--- a/Buffer/includes/Buffer.h
+++ b/Buffer/includes/Buffer.h
@@ -20,6 +20,8 @@
 #include <malloc.h>
 #include "../../Compatibility/compab.h"
 
+#include "../../Parser/includes/TokenSequence.h"
+
 #define BUFFER_SIZE 2048
 #define BUFFER_ALIGNMENT 4096
 
@@ -39,6 +41,10 @@ class Buffer {
     bool shouldLoadNewPortion;
 
     char *currentWorkingBuffer;
+
+    IdentifiableStream outputStreams[];
+    int maximumOfOutstreams;
+    int containedStreams;
 public:
 	~Buffer();
 	Buffer(char *pathToFile);
@@ -46,6 +52,7 @@ public:
 	void ungetChar(int back);
 	void load(void * someBuffer);
 	void allocateBufferMemory();
+	void printInStream(char* toPrint, char* streamID);
 };
 
 

--- a/Buffer/src/Buffer.cpp
+++ b/Buffer/src/Buffer.cpp
@@ -8,6 +8,11 @@
 Buffer::~Buffer() {
 	/* Close file descriptor */
 	close(fd);
+	// Close all output filestreams and delete stream array
+	for (int i = 0; i < this->containedStreams; i++) {
+		this->outputStreams[i].stream.close();
+	}
+	delete[] this->outputStreams;
 }
 
 Buffer::Buffer(char *pathToFile) {
@@ -17,6 +22,9 @@ Buffer::Buffer(char *pathToFile) {
 	shift = 0;
 	isAnymoreToRead = true;
 	shouldLoadNewPortion = true;
+	outputStreams = new IdentifiableStream[5]; // actually a size of 2 would suffice but let's say 5 to keep it general
+	maximumOfOutstreams = 5;
+	containedStreams = 0;
 }
 
 char Buffer::getChar() {
@@ -84,3 +92,27 @@ void Buffer::allocateBufferMemory() {
 	    next = buffer1;
 }
 
+void Buffer::printInStream(char* toPrint, char* streamID) {
+	IdentifiableStream outstream;
+	bool streamFound = false;
+	// try finding a stream with the given ID in the array of stored streams
+	for (int i = 0; i < this->containedStreams; i++) {
+		if (this->outputStreams[i].streamID == streamID) {
+			outstream = this->outputStreams[i];
+			streamFound = true;
+			break;
+		}
+	}
+	if (!streamFound) {
+		// open new stream and store it, or throw an error if it cannot be stored
+		if (&& this->containedStreams < this->maximumOfOutstreams) {
+			outstream.streamID = streamID;
+			outstream.stream.open(getFilepathByID(streamID));
+			this->outputStreams[this->containedStreams++] = outstream;
+		} else {
+			// TODO throw error with message "Could not store another output filestream"
+		}
+	}
+	// print the given text into the stream
+	outstream.stream << toPrint;
+}

--- a/Parser/includes/Parser.h
+++ b/Parser/includes/Parser.h
@@ -13,7 +13,6 @@
 
 class Parser {
 private:
-	// might be incomplete
 	TokenSequence* currentCodeSnippet;
 	TokenSequence* composeTable(char* filename);
 	void buildDecl (Decl** toBuild, TokenSequence* relatedSequence);

--- a/Parser/includes/TokenSequence.h
+++ b/Parser/includes/TokenSequence.h
@@ -10,6 +10,8 @@
 
 #include "../../Compatibility/compab.h"
 #include "../../Scanner/includes/Token.h"
+#include <iostream>
+#include <fstream>
 
 typedef enum {
 	AND,
@@ -19,6 +21,11 @@ typedef enum {
 	XOR,
 	XNOR
 }CheckoutMode;
+
+typedef struct {
+	char* streamID;
+	std::ofstream stream;
+}IdentifiableStream;
 
 class TokenSequence {
 private:
@@ -91,5 +98,16 @@ public:
 	int getSize();
 	~IntQueue();
 };
+
+class LabelFactory {
+private:
+	int currentLabelNo;
+public:
+	LabelFactory(int firstLabelNo);
+	int newLabel();
+	~LabelFactory();
+};
+
+const char* getFilepathByID(char* filestreamID);
 
 #endif /* PARSER_INCLUDES_TOKENSEQUENCE_H_ */

--- a/Parser/src/ParseTree.cpp
+++ b/Parser/src/ParseTree.cpp
@@ -25,6 +25,19 @@ TokenTypeRegistry* ParseTree::first() {
 	return nullptr; // no actual first() of abstract ParseTree
 }
 
+void ParseTree::prepareTreeOperations() { // to be called before running typeCheck()
+	ParseTree::typeTable = new Symboltable();
+	ParseTree::codeWriter = new Buffer(nullptr);
+	ParseTree::labelFactory = new LabelFactory(1);
+}
+
+void ParseTree::terminateTreeOperations() { // to be called at the end of main()
+	delete ParseTree::splitIndexes;
+	delete ParseTree::typeTable;
+	delete ParseTree::codeWriter;
+	delete ParseTree::labelFactory;
+}
+
 void Prog::initStatic() {
 	ProgOnly::initStatic();
 }
@@ -262,12 +275,30 @@ bool ProgOnly::isMatching(TokenSequence* sequence) {
 ProgOnly::ProgOnly() {
 	this->declarationSegment = nullptr;
 	this->statementSegment = nullptr;
+	this->checkingType = uncheckedType;
 }
 
 TokenTypeRegistry* ProgOnly::first() {
 	TokenTypeRegistry* registry = Decls::first();
 	registry->uniteWith(Statements::first()); // Decls::first() contains Epsilon, Statements::first() too so no need to remove it before merging
 	return registry;
+}
+
+bool ProgOnly::typeCheck() {
+	if (!this->declarationSegment->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (!this->statementSegment->typeCheck()) {
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void ProgOnly::makeCode() {
+	this->declarationSegment->makeCode();
+	this->statementSegment->makeCode();
+	ParseTree::codeWriter->printInStream("STP", "code");
 }
 
 ProgOnly::~ProgOnly() {
@@ -310,10 +341,27 @@ bool DeclsSeq::isMatching(TokenSequence* sequence) {
 DeclsSeq::DeclsSeq() {
 	this->firstDeclaration = nullptr;
 	this->restOfDeclarations = nullptr;
+	this->checkingType = uncheckedType;
 }
 
 TokenTypeRegistry* DeclsSeq::first() {
-	return Decl::first(); // no Epsilon in Decl::first()
+	return Decl::first(); // no Epsilon in Decl::first() so no merging with Decls::first()
+}
+
+bool DeclsSeq::typeCheck() {
+	if (!this->firstDeclaration->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (!this->restOfDeclarations->typeCheck()) {
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void DeclsSeq::makeCode() {
+	this->firstDeclaration->makeCode();
+	this->restOfDeclarations->makeCode();
 }
 
 bool DeclsSeq::isEps() {
@@ -341,6 +389,13 @@ TokenTypeRegistry* DeclsEps::first() {
 	registry->set(DeclsEps::epsToken);
 	return registry;
 }
+
+bool DeclsEps::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void DeclsEps::makeCode() {}
 
 bool DeclsEps::isEps() {
 	return true;
@@ -376,6 +431,31 @@ TokenTypeRegistry* DeclOnly::first() {
     return sequence;
 }
 
+bool DeclOnly::typeCheck() {
+	if (!this->size->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() != noType) {
+	    // TODO print error
+		ERROR_EXIT
+	}
+	if (this->size->checkingType == errorType) {
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	if (this->size->checkingType == arrayType) {
+		ParseTree::typeTable->attachType(this->identifier->getLexem(), intArrayType);
+	} else {
+		ParseTree::typeTable->attachType(this->identifier->getLexem(), intType);
+	}
+	return true;
+}
+
+void DeclOnly::makeCode() {
+	ParseTree::codeWriter->printInStream(("DS $%s ", this->identifier->getLexem()), "code");
+	this->size->makeCode();
+}
+
 DeclOnly::~DeclOnly() {
 	delete this->identifier;
 	delete this->size;
@@ -407,6 +487,19 @@ TokenTypeRegistry* ArrayIndex::first() {
 	return sequence;
 }
 
+bool ArrayIndex::typeCheck() {
+	if (this->integer->getValue() < 0) {
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void ArrayIndex::makeCode() {
+	char* printableCode = ("%i\n", this->integer->getValue()); // must use extra variable or the compiler doesn't understand the wildcarding
+	ParseTree::codeWriter->printInStream(printableCode, "code");
+}
+
 ArrayIndex::~ArrayIndex() {
 	delete this->integer;
 }
@@ -430,6 +523,15 @@ TokenTypeRegistry* ArrayEps::first() {
 
 bool ArrayEps::isEps() {
 	return true;
+}
+
+bool ArrayEps::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void ArrayEps::makeCode() {
+	ParseTree::codeWriter->printInStream("1\n", "code");
 }
 
 ArrayEps::~ArrayEps() {}
@@ -475,6 +577,22 @@ TokenTypeRegistry* StatementsSeq::first() {
 	return Statement::first();
 }
 
+bool StatementsSeq::typeCheck() {
+	if (!this->firstStatement->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (!this->restOfStatements->typeCheck()) {
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void StatementsSeq::makeCode() {
+	this->firstStatement->makeCode();
+	this->restOfStatements->makeCode();
+}
+
 bool StatementsSeq::isEps() {
 	return false;
 }
@@ -503,6 +621,15 @@ TokenTypeRegistry* StatementsEps::first() {
 
 bool StatementsEps::isEps() {
 	return true;
+}
+
+bool StatementsEps::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void StatementsEps::makeCode() {
+	ParseTree::codeWriter->printInStream("NOP\n", "code");
 }
 
 StatementsEps::~StatementsEps() {}
@@ -562,6 +689,39 @@ TokenTypeRegistry* StatementSetValue::first() {
 	return sequence;
 }
 
+bool StatementSetValue::typeCheck() {
+	if (!this->aimValue->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (!this->index->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() == noType) {
+	    // TODO print error
+	    ERROR_EXIT
+	}
+	if (this->aimValue->checkingType != intType) {
+		// TODO print error
+		ERROR_EXIT
+	}
+	if (   (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() != intType
+	        || this->index->checkingType != noType)
+	    && (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() != intArrayType
+	        || this->index->checkingType != arrayType)) {
+	    // TODO print error
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void StatementSetValue::makeCode() {
+	this->aimValue->makeCode();
+	ParseTree::codeWriter->printInStream(("LA $%s\n", this->identifier->getLexem()), "code");
+	this->index->makeCode();
+	ParseTree::codeWriter->printInStream("STR\n", "code");
+}
+
 StatementSetValue::~StatementSetValue() {
 	delete this->identifier;
 	delete this->index;
@@ -599,6 +759,19 @@ TokenTypeRegistry* StatementWrite::first() {
 	TokenTypeRegistry sequence = new TokenTypeRegistry ();
 	sequence.set(StatementWrite::firstToken);
 	return sequence;
+}
+
+bool StatementWrite::typeCheck() {
+	if (!this->toPrint->typeCheck()) {
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void StatementWrite::makeCode() {
+	this->toPrint->makeCode();
+	ParseTree::codeWriter->printInStream("PRI\n", "code");
 }
 
 StatementWrite::~StatementWrite() {
@@ -640,6 +813,31 @@ TokenTypeRegistry* StatementRead::first() {
 	return sequence;
 }
 
+bool StatementRead::typeCheck() {
+	if (!this->index->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() == noType) {
+	    // TODO print error
+		ERROR_EXIT
+	}
+	if (   (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() != intType
+	        || this->index->checkingType != noType)
+	    && (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() != intArrayType
+	        || this->index->checkingType != arrayType)) {
+	    // TODO print error
+	    ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void StatementRead::makeCode() {
+	ParseTree::codeWriter->printInStream(("REA\nLA $%s\n", this->identifier->getLexem()), "code");
+	this->index->makeCode();
+	ParseTree::codeWriter->printInStream("STR\n", "code");
+}
+
 StatementRead::~StatementRead() {
 	delete this->identifier;
 	delete this->index;
@@ -674,6 +872,18 @@ TokenTypeRegistry* StatementBlock::first() {
 	TokenTypeRegistry sequence = new TokenTypeRegistry();
 	sequence.set(StatementBlock::firstToken);
 	return sequence;
+}
+
+bool StatementBlock::typeCheck() {
+	if (!this->blockContent->typeCheck()) {
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void StatementBlock::makeCode() {
+	this->blockContent->makeCode();
 }
 
 StatementBlock::~StatementBlock() {
@@ -764,6 +974,38 @@ TokenTypeRegistry* StatementIfElse::first() {
 	return sequence;
 }
 
+bool StatementIfElse::typeCheck() {
+	if (!this->condition->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (this->condition->checkingType == errorType) {
+		ERROR_EXIT
+	}
+	if (!this->thenCase->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (!this->elseCase->typeCheck()) {
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void StatementIfElse::makeCode() {
+	int label1 = ParseTree::labelFactory->newLabel();
+	char* preparedString1 = ("JIN #%i\n", label1); // for some reason strings with int wildcards must be prepared in extra variables
+	char* preparedString3 = ("#%i NOP\n", label1); // numbered after sorting by usage ocurrence
+	int label2 = ParseTree::labelFactory->newLabel();
+	char* preparedString2 = ("JMP #%i\n", label2);
+	char* preparedString4 = ("#%i NOP\n", label2);
+	this->condition->makeCode();
+	ParseTree::codeWriter->printInStream(preparedString1, "code");
+	this->thenCase->makeCode();
+	ParseTree::codeWriter->printInStream(("%s%s", preparedString2, preparedString3), "code");
+	this->elseCase->makeCode();
+	ParseTree::codeWriter->printInStream(preparedString4, "code");
+}
+
 StatementIfElse::~StatementIfElse() {
 	delete this->condition;
 	delete this->thenCase;
@@ -815,6 +1057,34 @@ TokenTypeRegistry* StatementWhile::first() {
 	return sequence;
 }
 
+bool StatementWhile::typeCheck() {
+	if (!this->condition->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (this->condition->checkingType == errorType) {
+		ERROR_EXIT
+	}
+	if (!this->loop->typeCheck()) {
+		ERROR_EXIT
+	}
+	this->checkingType = noType;
+	return true;
+}
+
+void StatementWhile::makeCode() {
+	int label1 = ParseTree::labelFactory->newLabel();
+	char* preparedString1 = ("#%i NOP\n", label1);
+	char* preparedString3 = ("JMP #%i\n", label1);
+	int label2 = ParseTree::labelFactory->newLabel();
+	char* preparedString2 = ("JIN #%i\n", label2);
+	char* preparedString4 = ("#%i NOP\n", label2);
+	ParseTree::codeWriter->printInStream(preparedString1, "code");
+	this->condition->makeCode();
+	ParseTree::codeWriter->printInStream(preparedString2, "code");
+	this->loop->makeCode();
+	ParseTree::codeWriter->printInStream(("%s%s", preparedString3, preparedString4), "code");
+}
+
 StatementWhile::~StatementWhile() {
 	delete this->condition;
 	delete this->loop;
@@ -849,6 +1119,38 @@ ExpOnly::ExpOnly() {
 
 TokenTypeRegistry* ExpOnly::first() {
 	return Exp2::first();
+}
+
+bool ExpOnly::typeCheck() {
+	if (!this->rawExpression->typeCheck()
+	 || !this->calculateWith->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (this->calculateWith->checkingType == noType
+	 || this->calculateWith->checkingType == this->rawExpression->checkingType) {
+		this->checkingType = this->rawExpression->checkingType;
+		return true;
+	}
+	ERROR_EXIT
+}
+
+void ExpOnly::makeCode() {
+	if (this->calculateWith->checkingType != noType
+	 && ((OpExpNext*)this->calculateWith)->isOperatorGreater()) {
+		this->calculateWith->makeCode();
+	}
+	this->rawExpression->makeCode();
+	if (this->calculateWith->checkingType != noType) {
+		if (!((OpExpNext*)this->calculateWith)->isOperatorGreater()) {
+			this->calculateWith->makeCode();
+			if (((OpExpNext*)this->calculateWith)->isOperatorNotEquals()) {
+				ParseTree::codeWriter->printInStream("NOT\n", "code");
+			}
+		}
+		else {
+			ParseTree::codeWriter->printInStream("LES\n", "code");
+		}
+	}
 }
 
 ExpOnly::~ExpOnly() {
@@ -890,6 +1192,15 @@ TokenTypeRegistry* Exp2Nested::first() {
 	return sequence;
 }
 
+bool Exp2Nested::typeCheck() {
+	this->checkingType = this->nestedExpression->typeCheck() ? this->nestedExpression->checkingType : errorType;
+	return this->checkingType != errorType;
+}
+
+void Exp2Nested::makeCode() {
+	this->nestedExpression->makeCode();
+}
+
 Exp2Nested::~Exp2Nested() {
 	delete this->nestedExpression;
 }
@@ -923,6 +1234,34 @@ TokenTypeRegistry* Exp2Variable::first() {
 	return sequence;
 }
 
+bool Exp2Variable::typeCheck() {
+	if (!this->index->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() == noType) {
+		// TODO print error
+	    ERROR_EXIT
+	}
+	if (   (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() != intType
+	        || this->index->checkingType != noType)
+	    && (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() != intArrayType
+	        || this->index->checkingType != arrayType)) {
+	    if (ParseTree::typeTable->lookup(this->identifier->getLexem())->getType() == intArrayType
+	    	|| this->index->checkingType == noType) {
+	    	// TODO print error
+	    }
+		ERROR_EXIT
+	}
+	this->checkingType = intType;
+	return true;
+}
+
+void Exp2Variable::makeCode() {
+	ParseTree::codeWriter->printInStream(("LA $%s\n", this->identifier->getLexem()), "code");
+	this->index->makeCode();
+	ParseTree::codeWriter->printInStream("LV\n", "code");
+}
+
 Exp2Variable::~Exp2Variable() {
 	delete this->identifier;
 	delete this->index;
@@ -945,6 +1284,16 @@ TokenTypeRegistry* Exp2Constant::first() {
 	TokenTypeRegistry* sequence = new TokenTypeRegistry ();
 	sequence->set(Exp2Constant::defaultInteger);
 	return sequence;
+}
+
+bool Exp2Constant::typeCheck() {
+	this->checkingType = intType;
+	return true;
+}
+
+void Exp2Constant::makeCode() {
+	char* preparedString = ("LC %i", this->integer->getValue());
+	ParseTree::codeWriter->printInStream(preparedString, "code");
 }
 
 Exp2Constant::~Exp2Constant() {
@@ -979,6 +1328,18 @@ TokenTypeRegistry* Exp2NumericNegation::first() {
 	return sequence;
 }
 
+bool Exp2NumericNegation::typeCheck() {
+	bool result = this->toNegate->typeCheck();
+	this->checkingType = this->toNegate->checkingType;
+	return result;
+}
+
+void Exp2NumericNegation::makeCode() {
+	ParseTree::codeWriter->printInStream("LC 0\n", "code");
+	this->toNegate->makeCode();
+	ParseTree::codeWriter->printInStream("SUB\n", "code");
+}
+
 Exp2NumericNegation::~Exp2NumericNegation() {
 	delete this->toNegate;
 }
@@ -1009,6 +1370,20 @@ TokenTypeRegistry* Exp2LogicalNegation::first() {
 	TokenTypeRegistry sequence = new TokenTypeRegistry ();
 	sequence.set(Exp2LogicalNegation::firstToken);
 	return sequence;
+}
+
+bool Exp2LogicalNegation::typeCheck() {
+	if (!this->toNegate->typeCheck()
+	 || this->toNegate->checkingType != intType) {
+		ERROR_EXIT
+	}
+	this->checkingType = intType;
+	return true;
+}
+
+void Exp2LogicalNegation::makeCode() {
+	this->toNegate->makeCode();
+	ParseTree::codeWriter->printInStream("NOT\n", "code");
 }
 
 Exp2LogicalNegation::~Exp2LogicalNegation() {
@@ -1053,6 +1428,19 @@ TokenTypeRegistry* IndexPosition::first() {
 	return sequence;
 }
 
+bool IndexPosition::typeCheck() {
+	if (!this->index->typeCheck() || this->index->checkingType == errorType) {
+		ERROR_EXIT
+	}
+	this->checkingType = arrayType;
+	return true;
+}
+
+void IndexPosition::makeCode() {
+	this->index->makeCode();
+	ParseTree::codeWriter->printInStream("ADD\n", "code");
+}
+
 IndexPosition::~IndexPosition() {
 	delete this->index;
 }
@@ -1077,6 +1465,13 @@ TokenTypeRegistry* IndexEps::first() {
 bool IndexEps::isEps() {
 	return true;
 }
+
+bool IndexEps::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void IndexEps::makeCode() {}
 
 IndexEps::~IndexEps() {}
 
@@ -1106,6 +1501,30 @@ bool OpExpNext::isEps() {
 	return false;
 }
 
+bool OpExpNext::isOperatorGreater() {
+	return this->Operator->first()->isSet(nullptr); // TODO replace nullptr by ParseTree::greaterToken
+}
+
+bool OpExpNext::isOperatorNotEquals() {
+	return this->Operator->first()->isSet(nullptr); // TODO replace nullptr by ParseTree::notEqualsToken
+}
+
+bool OpExpNext::typeCheck() {
+	if (!this->Operator->typeCheck()) {
+		ERROR_EXIT
+	}
+	if (!this->operand->typeCheck()) {
+		ERROR_EXIT
+	}
+	this->checkingType = this->operand->checkingType;
+	return true;
+}
+
+void OpExpNext::makeCode() {
+	this->operand->makeCode();
+	this->Operator->makeCode();
+}
+
 OpExpNext::~OpExpNext() {
 	delete this->Operator;
 	delete this->operand;
@@ -1132,6 +1551,13 @@ bool OpExpEps::isEps() {
 	return true;
 }
 
+bool OpExpEps::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpExpEps::makeCode() {}
+
 OpExpEps::~OpExpEps() {}
 
 void OpPlus::initStatic() {
@@ -1148,6 +1574,15 @@ TokenTypeRegistry* OpPlus::first() {
 	TokenTypeRegistry* sequence = new TokenTypeRegistry ();
 	sequence->set(OpPlus::firstToken);
 	return sequence;
+}
+
+bool OpPlus::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpPlus::makeCode() {
+	ParseTree::codeWriter->printInStream("ADD\n", "code");
 }
 
 OpPlus::~OpPlus() {}
@@ -1168,6 +1603,15 @@ TokenTypeRegistry* OpMinus::first() {
 	return sequence;
 }
 
+bool OpMinus::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpMinus::makeCode() {
+	ParseTree::codeWriter->printInStream("SUB\n", "code");
+}
+
 OpMinus::~OpMinus() {}
 
 void OpMult::initStatic() {
@@ -1184,6 +1628,15 @@ TokenTypeRegistry* OpMult::first() {
 	TokenTypeRegistry* sequence = new TokenTypeRegistry ();
 	sequence->set(OpMult::firstToken);
 	return sequence;
+}
+
+bool OpMult::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpMult::makeCode() {
+	ParseTree::codeWriter->printInStream("MUL\n", "code");
 }
 
 OpMult::~OpMult() {}
@@ -1204,6 +1657,15 @@ TokenTypeRegistry* OpDiv::first() {
 	return sequence;
 }
 
+bool OpDiv::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpDiv::makeCode() {
+	ParseTree::codeWriter->printInStream("DIV\n", "code");
+}
+
 OpDiv::~OpDiv() {}
 
 void OpLess::initStatic() {
@@ -1220,6 +1682,15 @@ TokenTypeRegistry* OpLess::first() {
 	TokenTypeRegistry* sequence = new TokenTypeRegistry ();
 	sequence->set(OpLess::firstToken);
 	return sequence;
+}
+
+bool OpLess::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpLess::makeCode() {
+	ParseTree::codeWriter->printInStream("LES\n", "code");
 }
 
 OpLess::~OpLess() {}
@@ -1240,6 +1711,13 @@ TokenTypeRegistry* OpGreater::first() {
 	return sequence;
 }
 
+bool OpGreater::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpGreater::makeCode() {}
+
 OpGreater::~OpGreater() {}
 
 void OpEquals::initStatic() {
@@ -1256,6 +1734,15 @@ TokenTypeRegistry* OpEquals::first() {
 	TokenTypeRegistry* sequence = new TokenTypeRegistry ();
 	sequence->set(OpEquals::firstToken);
 	return sequence;
+}
+
+bool OpEquals::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpEquals::makeCode() {
+	ParseTree::codeWriter->printInStream("EQU\n", "code");
 }
 
 OpEquals::~OpEquals() {}
@@ -1276,6 +1763,15 @@ TokenTypeRegistry* OpNotEquals::first() {
 	return sequence;
 }
 
+bool OpNotEquals::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpNotEquals::makeCode() {
+	ParseTree::codeWriter->printInStream("EQU\n", "code");
+}
+
 OpNotEquals::~OpNotEquals() {}
 
 void OpAnd::initStatic() {
@@ -1292,6 +1788,15 @@ TokenTypeRegistry* OpAnd::first() {
 	TokenTypeRegistry* sequence = new TokenTypeRegistry ();
 	sequence->set(OpAnd::firstToken);
 	return sequence;
+}
+
+bool OpAnd::typeCheck() {
+	this->checkingType = noType;
+	return true;
+}
+
+void OpAnd::makeCode() {
+	ParseTree::codeWriter->printInStream("AND\n", "code");
 }
 
 OpAnd::~OpAnd() {}

--- a/Parser/src/Parser.cpp
+++ b/Parser/src/Parser.cpp
@@ -339,7 +339,6 @@ Parser::~Parser() {
 	delete ParseTree::identifierToken;
 	delete ParseTree::integerToken;
 	delete ParseTree::minusToken;
-	delete ParseTree::splitIndexes;
 	delete DeclOnly::firstToken;
 	delete StatementWrite::firstToken;
 	delete StatementRead::firstToken;

--- a/Parser/src/TokenSequence.cpp
+++ b/Parser/src/TokenSequence.cpp
@@ -16,6 +16,18 @@ TokenSequence::TokenSequence(int initialCapacity, int initialIncrement) {
 	this->tokensReferenced = true;
 }
 
+TokenSequence::TokenSequence(TokenSequence* other) {
+	this->capacity = other->capacity;
+	this->increment = other->increment;
+	this->sequence = new Token*[this->capacity];
+	for (int i = 0; i < other->size; i++) {
+		this->sequence[i] = other->sequence[i];
+	}
+	this->size = other->size;
+	this->currentPos = other->currentPos;
+	this->tokensReferenced = other->tokensReferenced;
+}
+
 void TokenSequence::add (Token* token, bool setAsCurrent) {
 	if (this->size == this->capacity) {
 		Token* temp[] = this->sequence;
@@ -79,10 +91,14 @@ TokenSequence* TokenSequence::splitOn(int index, TokenSequence** subsequence2) {
 	}
 	TokenSequence* subsequence1 = new TokenSequence (10, 10);
 	*subsequence2 = new TokenSequence (10, 10);
-	// TODO modify subsequences so that:
-	// - subsequence1 contains all Tokens from first (inclusive) to index (inclusive)
-	// - subsequence2 contains all Tokens from index (exclusive) to last (inclusive)
-	// - no array copy loop is involved
+	// entire array is being copied -> might be a runtime issue
+	for (int i = 0; i < this->size; i++) {
+		if (i <= index) {
+			subsequence1->add(this->sequence[i], false);
+		} else {
+			(*subsequence2)->add(this->sequence[i], false);
+		}
+	}
 	return subsequence1;
 }
 
@@ -257,4 +273,27 @@ int IntQueue::getSize() {
 IntQueue::~IntQueue() {
 	delete this->first;
 	delete this->last;
+}
+
+LabelFactory::LabelFactory(int firstLabelNo) {
+	this->currentLabelNo = firstLabelNo;
+}
+
+int LabelFactory::newLabel() {
+	return this->currentLabelNo++;
+}
+
+LabelFactory::~LabelFactory() {}
+
+const char* getFilepathByID(char* filestreamID) {
+	switch (filestreamID) {
+	case "code":
+		return "../../debug/test.code";
+	case "scan":
+		return "../../debug/output.txt";
+	// for each additional output filestream a case must be added
+	default:
+		// TODO throw error with message "Stream ID is not registered"
+		return nullptr;
+	}
 }

--- a/Scanner/includes/Information.h
+++ b/Scanner/includes/Information.h
@@ -8,15 +8,29 @@
 #ifndef SCANNER_INCLUDES_INFORMATION_H_
 #define SCANNER_INCLUDES_INFORMATION_H_
 
+#include "../../Symboltable/includes/Symboltable.h"
+
+typedef enum {
+	uncheckedType,
+	intType,
+	intArrayType,
+	arrayType,
+	noType,
+	errorType
+}CheckableType;
+
 class Information {
 	char* lexem;
+	CheckableType type;
 public:
 	Information();
 	Information(char* lexem);
 	virtual ~Information();
 	void setLexem(char* lexem);
 	char* getLexem();
+	CheckableType getType();
 	bool matches(char* other);
+	friend void Symboltable::attachType(char* lexem, CheckableType type);
 };
 
 

--- a/Scanner/src/Scanner.cpp
+++ b/Scanner/src/Scanner.cpp
@@ -89,7 +89,7 @@ Token *Scanner::nextToken() {
 }
 
 /*
- * determine the actual token type relying on STATE and LEXEM
+ * determine the current token type relying on STATE and LEXEM
  * @return token's type
  */
 int Scanner::mapStateToType(int state, char* lexem) {

--- a/Symboltable/includes/Symboltable.h
+++ b/Symboltable/includes/Symboltable.h
@@ -30,6 +30,7 @@ public:
 	int hash(char *lexem);
 	SymtabEntry* insert(char *lexem, int size);
 	Information* lookup(char* lexem);
+	void attachType (char* lexem, CheckableType type);
 	void initSymbols();
 	void print();
 };

--- a/Symboltable/src/Symboltable.cpp
+++ b/Symboltable/src/Symboltable.cpp
@@ -79,20 +79,20 @@ void Symboltable::print() {
 
 
 void Symboltable::initSymbols() {
-	/*
+
 	insert("write", 5);
 	insert("WRITE", 5);
 	insert("read", 4);
 	insert("READ", 4);
-	*/
+
 	insert("if", 2);
 	insert("IF", 2);
-	/*
+
 	insert("else", 4);
 	insert("ELSE", 4);
 	insert("int", 3);
 	insert("INT", 3);
-	*/
+
 	insert("while", 5);
 	insert("WHILE", 5);
 }


### PR DESCRIPTION
finished typeCheck() and makeCode() in ParseTree, adding output stream
management functionality to the Buffer and adding a LabelFactory class
to the TokenSequence system
additionally re-included the four outcommented Token types (write,read,
else, int)
caution: does NOT include the recent bugfixes, nor the makefile! backup repository before
checkout to copypaste them